### PR TITLE
✨ Parse compile time variables from listing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gams-ide",
   "displayName": "gams-ide",
   "description": "A GAMS integrated development environment for VSCode",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/chrispahm/gams-ide"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,9 @@ const config = {
   externals: {
     vscode: 'commonjs vscode'
   },
+  optimization: {
+    minimize: true
+  },
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
     mainFields: ['browser', 'module', 'main'], // look for `browser` entry point in imported node modules


### PR DESCRIPTION
fixes #40 

## New Features
### Parse compile time variables from listing
If the compile-time variable listing is present, GAMS-IDE will parse the values of compile time variables and show them in the sidebar, data panel, and in the hover info
<img width="678" alt="image" src="https://github.com/chrispahm/gams-ide/assets/20703207/d535a823-b7ca-4e89-b2e6-2fe979c9c80b">
