### PR TITLE
⚡ switch to compile.gms root, unlink files after compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ node_modules
 scrdir/*
 docs/.vitepress/cache
 docs/.vitepress/dist
-dist
+dist/*
+!dist/compile.gms

--- a/dist/compile.gms
+++ b/dist/compile.gms
@@ -1,0 +1,3 @@
+$include %gamsFileToRun%
+$onInclude
+$showVariables

--- a/src/createIncludeTree.js
+++ b/src/createIncludeTree.js
@@ -143,6 +143,14 @@ function parseIncludeFileSummary(lstFile, state) {
         let tokens = line.split(/\s+/);
         // If the line has six tokens, then it is a valid entry
         if (tokens.length === 7) {
+          // since we use the compile.gms file as the root, we need to remove it from the include file summary
+          if (parseInt(tokens[1]) === 1 && tokens[3] === "INPUT") {
+            // skip this entry, as it's the compile.gms file
+            return;
+          } else if (parseInt(tokens[1]) === 2) {
+            // this is the actual main file
+            tokens[3] = "INPUT";
+          }
           // Create an object with properties corresponding to each column
           let file = {
             seq: parseInt(tokens[1]), // Parse the sequence number as an integer

--- a/src/utils/createGamsCompileCommand.js
+++ b/src/utils/createGamsCompileCommand.js
@@ -97,8 +97,10 @@ module.exports = async function createGamsCommand(docFileName, extraArgs = []) {
   const randStr = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
   let randBasePath = `${scratchDirectory}${sep}${randStr}`;
 
+  const compileGamsFilePath = `${__dirname}${sep}compile.gms`;
+
   let gamsArgs = [
-    `"${gamsFileToExecute}"`, 'LO=3', "a=c", 
+    `"${compileGamsFilePath}"`, `--gamsFileToRun="${gamsFileToExecute}"`, 'LO=3', "a=c", 
     `o="${randBasePath}.lst"`, 
     `fErr="${randBasePath}.err"`,
     `rf="${randBasePath}.ref"`,


### PR DESCRIPTION
This PR switches from compiling the current main GAMS file to a root `compile.gms` as discussed in https://forum.gamsworld.org/viewtopic.php?p=31007#p31007.

Using the root `compile.gms` allows us to set a few environment variables such as $onInclude and $showVariables, so that the "GAMS Model Tree" view and parsing of GAMS global/local variables work without user input.

## Bug Fixes
- Fixes include file summary not being parsed due to $offInclude being set somewhere in the GAMS code
- Fixes global variables not being parsed due to $show or $showVariables not being present in the GAMS code
- Unlinks .err and .lst files after compilation